### PR TITLE
Fixing issues in lambda map-reduce exercise

### DIFF
--- a/chryswoods.com/parallel_python/lambda_answer1.md
+++ b/chryswoods.com/parallel_python/lambda_answer1.md
@@ -11,10 +11,14 @@ filenames = sys.argv[1:]
 
 # map the count_lines function against all of the
 # files listed in "filenames"
-results = map(lambda x: len(open(x, "r").readlines()), filenames)
+results = list(map(lambda x: len(open(x, "r").readlines()), filenames))
 
 # Now print out all of the totals
-map(lambda x, y: print("%s contains %s lines" % (x, y)), filenames, results)
+string_results = map(lambda x, y: "%s contains %s lines" % (x, y), filenames, results)
+
+# Join the list of strings using a newline character
+# and print to screen.
+print("\n".join(string_results))
 
 total = reduce(lambda x,y: x+y, results)
 

--- a/chryswoods.com/parallel_python/lambda_answer1.md
+++ b/chryswoods.com/parallel_python/lambda_answer1.md
@@ -5,6 +5,8 @@ from __future__ import print_function
 
 import sys
 
+from functools import reduce
+
 # get all of the names of the plays from
 # the command line
 filenames = sys.argv[1:]


### PR DESCRIPTION
1) Adding missing `from functools import reduce`
2) Convert the `results` map to a list so that it can be used multiple times.
3) Remove print statement from within lambda function. This doesn't seem to work in Python 3 (not sure why). Instead, return a list of strings and print using join.