### PR TITLE
Updates for the 2019.1.0 Sire release

### DIFF
--- a/largefiles/sire_releases/redirect_sire_2019_1_0_linux.run
+++ b/largefiles/sire_releases/redirect_sire_2019_1_0_linux.run
@@ -1,0 +1,1 @@
+https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/UIH8J0BXS8pknH--L3BLVX2URdMni2I0blr8Ew3hJZ4/n/chryswoods/b/sire_releases/o/sire_2019_1_0_linux.run

--- a/largefiles/sire_releases/redirect_sire_2019_1_0_osx.run
+++ b/largefiles/sire_releases/redirect_sire_2019_1_0_osx.run
@@ -1,0 +1,1 @@
+https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/uXCHNEvPbRLLUi8VcH3HeowrcGQ9ndY690pcOripSxQ/n/chryswoods/b/sire_releases/o/sire_2019_1_0_osx.run

--- a/pages/binaries.md
+++ b/pages/binaries.md
@@ -2,30 +2,30 @@
 
 ## Linux (all distributions)
 
-A self-extracting binary that can run on most Linux distributions that were released after 2011 can 
+A self-extracting binary that can run on most Linux distributions that were released after 2011 can
 be downloaded here. Note this will only run on X86-64 processors that have AVX support (i.e. nearly
 all Intel and AMD processors released after 2011).
 
-[sire_2018_2_0_linux.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2018_2_0_linux.run) : 2018.2.0 release compiled for Linux [726 MB]
+[sire_2019_1_0_linux.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2019_1_0_linux.run) : 2019.1.0 release compiled for Linux [949 MB]
 
-MD5Sum = 31daea15eabae321960a5b12e5f99fea
+MD5Sum = b40592ec9b430dd4b9c0a58981fd7059
 
 You can also download the latest nightly development binary of Sire. This is a compiled binary of the latest version of the Sire `devel` branch in [GitHub](https://github.com/michellab/Sire).
 
-[sire_devel_latest_linux.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_devel_latest_linux.run) : Latest devel version, compiled for Linux [~1400 MB]
+[sire_devel_latest_linux.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_devel_latest_linux.run) : Latest devel version, compiled for Linux [~1000 MB]
 
 ## OS X (Mac)
 
 A self-extracting binary that can run OS X 10.9(Mavericks, released 2013) and above can be downloaded here. Note that
 this will only run on X86-64 processors that have AVX support (i.e. nearly all Intel and AMD processors released after 2011)
 
-[sire_2018_2_0_osx.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2018_2_0_osx.run) : 2018.2.0 release compiled for OS X [538 MB]
+[sire_2019_1_0_osx.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2019_1_0_osx.run) : 2019.1.0 release compiled for OS X [597 MB]
 
-MD5Sum = 2031d5e6dec47454d2acbb2fd05a1259
+MD5Sum = e7ceddf08b182907b49108363f60c2a1
 
 You can also download the latest nightly development binary of Sire. This is a compiled binary of the latest version of the Sire `devel` branch in [GitHub](https://github.com/michellab/Sire).
 
-[sire_devel_latest_osx.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_devel_latest_osx.run) : Latest devel version, compiled for OS X [~900 MB]
+[sire_devel_latest_osx.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_devel_latest_osx.run) : Latest devel version, compiled for OS X [~600 MB]
 
 ## Windows
 
@@ -40,8 +40,8 @@ is distributed as a zip file that must be unpacked in the C: drive (see instruct
 
 ## Installation (Linux and Mac)
 
-Once you have downloaded your sire_XXX.run file, simply run 
-it from the command line to unpack and install. 
+Once you have downloaded your sire_XXX.run file, simply run
+it from the command line to unpack and install.
 Assuming you have downloaded into the current directory, type
 
 ```
@@ -49,44 +49,44 @@ chmod a+x ./sire_XXX.run
 ./sire_XXX.run
 ```
 
-This will unpack Sire, and will then ask where you would like it to be installed. 
-By default, Sire will install to a directory called `sire.app` in your home directory. 
+This will unpack Sire, and will then ask where you would like it to be installed.
+By default, Sire will install to a directory called `sire.app` in your home directory.
 You can then run the Sire python environment by typing
 
 ```
 ~/sire.app/bin/python
 ```
 
-You can find other Sire executables in this directory, 
+You can find other Sire executables in this directory,
 e.g. the waterswap executable. To run waterswap, type
 
 ```
 ~/sire.app/bin/waterswap
 ```
 
-Use the `--help` option to get more information on how to run each executable, 
+Use the `--help` option to get more information on how to run each executable,
 and `--description` for a full description (same as the apps webpage).
 
-You can also find the `sire_test` executable that is used for running unit 
+You can also find the `sire_test` executable that is used for running unit
 tests to validate the installation. To run sire_test, type
 
 ```
 ~/sire.app/bin/sire_test
 ```
 
-Several sets of tests will be run, and you should see that there are 0 failures. 
-If any tests fail, then please post a bug report on [GitHub](https://github.com/michellab/Sire), 
+Several sets of tests will be run, and you should see that there are 0 failures.
+If any tests fail, then please post a bug report on [GitHub](https://github.com/michellab/Sire),
 together with a description of your system (Linux or Mac, which binary you downloaded,
 distribution etc.)
 
-If you have any problems, or would like Sire compiled for your distribution, 
+If you have any problems, or would like Sire compiled for your distribution,
 then please get in touch via the [Sire users mailing list](http://groups.google.com/group/sire-users).
 
 ## Installation (Windows)
 
-Unzip the zipfile into your C: directory. This should create `C:\sire`. You can the included MINGW64 
+Unzip the zipfile into your C: directory. This should create `C:\sire`. You can the included MINGW64
 shell by running `C:\sire\mingw64.exe`. This will give you a command line. From here,
-you can run Sire applications by calling the Sire python scripts directly. These are 
+you can run Sire applications by calling the Sire python scripts directly. These are
 located in `/mingw64/share/Sire/scripts`, i.e.
 
 ```
@@ -102,8 +102,8 @@ of Sire.
 
 ## Older Versions
 
-Older binaries of Sire can be downloaded here. We always 
-recommend using the latest version, and only keep these 
+Older binaries of Sire can be downloaded here. We always
+recommend using the latest version, and only keep these
 links in case you want to reproduce an older simulation.
 
 ### Sire 2018.1.1

--- a/pages/binaries.md
+++ b/pages/binaries.md
@@ -24,8 +24,8 @@ this will only run on X86-64 processors that have AVX support (i.e. nearly all I
 MD5Sum = e7ceddf08b182907b49108363f60c2a1
 
 Note that on OS X you will need to run Python scripts with the `sire_python`
-interpreter. This is due to an issue with default Python interpreter that is
-installed via Conda.
+interpreter. This is due to an issue with the default Python interpreter that
+is installed via Conda.
 
 You can also download the latest nightly development binary of Sire. This is a compiled binary of the latest version of the Sire `devel` branch in [GitHub](https://github.com/michellab/Sire).
 

--- a/pages/binaries.md
+++ b/pages/binaries.md
@@ -23,6 +23,10 @@ this will only run on X86-64 processors that have AVX support (i.e. nearly all I
 
 MD5Sum = e7ceddf08b182907b49108363f60c2a1
 
+Note that on OS X you will need to run Python scripts with the `sire_python`
+interpreter. This is due to an issue with default Python interpreter that is
+installed via Conda.
+
 You can also download the latest nightly development binary of Sire. This is a compiled binary of the latest version of the Sire `devel` branch in [GitHub](https://github.com/michellab/Sire).
 
 [sire_devel_latest_osx.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_devel_latest_osx.run) : Latest devel version, compiled for OS X [~600 MB]

--- a/pages/download.md
+++ b/pages/download.md
@@ -117,6 +117,8 @@ optimise_openmm
 be location in `$HOME/sire.app/bin`.)
 
 Alternatively, to manually install a particular version of OpenMM you can
-use a specific Conda label, e.g.::
+use a specific Conda label, e.g.:
 
-    conda install -c omnia/label/cuda90 openmm
+```
+conda install -c omnia/label/cuda90 openmm
+```

--- a/pages/download.md
+++ b/pages/download.md
@@ -122,3 +122,8 @@ use a specific Conda label, e.g.:
 ```
 conda install -c omnia/label/cuda90 openmm
 ```
+
+If you have compiled Sire against a custom OpenMM installation, then you'll
+need to set the `OPENMM_PLUGIN_DIR` environment variable to point to the
+correct plugin location. By default this variable is set to the plugin
+directory of the bundled OpenMM package.

--- a/pages/download.md
+++ b/pages/download.md
@@ -114,7 +114,7 @@ optimise_openmm
 ```
 
 (Note that, depending on your installation method, `optimise_openmm` may
-be location in `$HOME/sire.app/bin`.)
+be located in `$HOME/sire.app/bin`.)
 
 Alternatively, to manually install a particular version of OpenMM you can
 use a specific Conda label, e.g.:

--- a/pages/download.md
+++ b/pages/download.md
@@ -29,8 +29,8 @@ conda update -c conda-forge -c omnia -c michellab/label/dev sire
 ```
 
 Note that on OS X you will need to run Python scripts with the `sire_python`
-interpreter. This is due to an issue with default Python interpreter that is
-installed via Conda.
+interpreter. This is due to an issue with the default Python interpreter that
+is installed via Conda.
 
 ## [Download a Sire binary](binaries.md)
 

--- a/pages/download.md
+++ b/pages/download.md
@@ -28,6 +28,10 @@ need to add them when updating, e.g., for the development package:
 conda update -c conda-forge -c omnia -c michellab/label/dev sire
 ```
 
+Note that on OS X you will need to run Python scripts with the `sire_python`
+interpreter. This is due to an issue with default Python interpreter that is
+installed via Conda.
+
 ## [Download a Sire binary](binaries.md)
 
 The latest release of Sire can be downloaded from

--- a/pages/download.md
+++ b/pages/download.md
@@ -30,7 +30,7 @@ conda update -c conda-forge -c omnia -c michellab/label/dev sire
 
 Note that on OS X you will need to run Python scripts with the `sire_python`
 interpreter. This is due to an issue with the default Python interpreter that
-is installed via Conda.
+is installed via Conda. (This applies to all installation methods.)
 
 ## [Download a Sire binary](binaries.md)
 


### PR DESCRIPTION
I've added a note regarding setting the `OPENMM_PLUGIN_DIR` environment variable when SIre is compiled against a custom OpenMM installation. (By default this is set to the location of the bundled OpenMM's plugin directory.)

I've also fixed a few typos and added download links for the 2019.1.0 release of Sire.