### PR TITLE
Remove details regarding sire_python macOS workaround

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -28,10 +28,6 @@ need to add them when updating, e.g., for the development package:
 conda update -c conda-forge -c omnia -c michellab/label/dev sire
 ```
 
-Note that on OS X you will need to run Python scripts with the `sire_python`
-interpreter. This is due to an issue with the default Python interpreter that
-is installed via Conda. (This applies to all installation methods.)
-
 ## [Download a Sire binary](binaries.md)
 
 The latest release of Sire can be downloaded from


### PR DESCRIPTION
I've fixed the segmentation fault issue that occurred when importing Sire within the Python interpreter from `conda-forge`. This was due to `libpython` being statically linked into the interpreter, so we needed to _not_ link against `libpython` when building the wrappers for macOS to avoid duplicating symbols. See [this](https://github.com/michellab/Sire/issues/292) issue thread for details, and [this](https://github.com/michellab/Sire/commit/d6c8b3b33508987a93a9a67787ec7ef9fe146630) commit for the fix. (We'd already implemented half the fix, just forgotten this part.)

This now means that macOS users aren't greeted with a segmentation fault as their first experience of using Sire or BioSimSpace! The source build, binary, and Conda package all work using both the `conda-forge` Python interpreter and `sire_python`.