### PR TITLE
Added note about std::map vs std::unordered_map and updates for the Sire 2019.3.0 release.

### DIFF
--- a/chryswoods.com/beginning_c++/lists.md
+++ b/chryswoods.com/beginning_c++/lists.md
@@ -221,6 +221,7 @@ Things to note about a C++ map versus a Python dictionary are;
 * Unlike Python, there is no `.keys()` or `.values()` function. You have to write these yourself...
 * When you loop through the values in a map, the iterated item is a key-value pair. In `for ( auto item : m )`, the type of `item` is a key-value pair. The key is the first item in the pair `item.first`, while the value is the second item `item.second`.
 * All keys in a map have to have the same type, and all values in a map have to have the same type, buy keys and values don't have to have the same type. For example, `std::map<float,std::string>` creates a map in which all keys are floats, and all values are strings.
+* The items in a `std::map` are _ordered_. If this isn't important to you, e.g. you are just doing pure lookup-retrieval rather than, say, looping over all of the data and printing/accessing it in order, then you can normally get much better perfromance using `std::unordered_map`. (Note that `std::unordered_map` can be slower if you are doing lots of insertion and deletion of elements and, in general, uses more memory.)
 
 You can use any type as a value in a map, including vectors or indeed other maps. For example, here we use a map of maps to record the weight and height of a range of people;
 

--- a/largefiles/sire_releases/redirect_sire_2019_3_0_linux.run
+++ b/largefiles/sire_releases/redirect_sire_2019_3_0_linux.run
@@ -1,0 +1,1 @@
+https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/7OYmY3Pe-dwjH9KoqxnIcRolX_YPu-4lXVfebkwSmL8/n/chryswoods/b/sire_releases/o/sire_2019_3_0_linux.run

--- a/largefiles/sire_releases/redirect_sire_2019_3_0_osx.run
+++ b/largefiles/sire_releases/redirect_sire_2019_3_0_osx.run
@@ -1,0 +1,1 @@
+https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/H3CHwN939UgwanzyplJdmZeNHLLC_0cJYcieJOT2gVk/n/chryswoods/b/sire_releases/o/sire_2019_3_0_osx.run

--- a/pages/binaries.md
+++ b/pages/binaries.md
@@ -6,9 +6,9 @@ A self-extracting binary that can run on most Linux distributions that were rele
 be downloaded here. Note this will only run on X86-64 processors that have AVX support (i.e. nearly
 all Intel and AMD processors released after 2011).
 
-[sire_2019_2_1_linux.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2019_2_1_linux.run) : 2019.2.1 release compiled for Linux [959 MB]
+[sire_2019_3_0_linux.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2019_3_0_linux.run) : 2019.3.0 release compiled for Linux [959 MB]
 
-MD5Sum = 37a2972a0ff817734dbd4845d6cb302c
+MD5Sum = c016e7e173afe211f822adae7ced66bf
 
 You can also download the latest nightly development binary of Sire. This is a compiled binary of the latest version of the Sire `devel` branch in [GitHub](https://github.com/michellab/Sire).
 
@@ -19,9 +19,9 @@ You can also download the latest nightly development binary of Sire. This is a c
 A self-extracting binary that can run OS X 10.9(Mavericks, released 2013) and above can be downloaded here. Note that
 this will only run on X86-64 processors that have AVX support (i.e. nearly all Intel and AMD processors released after 2011)
 
-[sire_2019_2_1_osx.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2019_2_1_osx.run) : 2019.2.1 release compiled for OS X [534 MB]
+[sire_2019_3_0_osx.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2019_3_0_osx.run) : 2019.3.0 release compiled for OS X [534 MB]
 
-MD5Sum = cc397ce110a1c2de95e6103535c48a22
+MD5Sum = 68f0d09fca91a8fa006a58dc2a743cf4
 
 You can also download the latest nightly development binary of Sire. This is a compiled binary of the latest version of the Sire `devel` branch in [GitHub](https://github.com/michellab/Sire).
 
@@ -105,6 +105,16 @@ of Sire.
 Older binaries of Sire can be downloaded here. We always
 recommend using the latest version, and only keep these
 links in case you want to reproduce an older simulation.
+
+### Sire 2019.2.1
+
+[sire_2019_2_1_linux.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2019_2_1_linux.run) : 2019.2.1 release compiled for Linux [959 MB]
+
+MD5Sum = 37a2972a0ff817734dbd4845d6cb302c
+
+[sire_2019_2_1_osx.run](https://siremol.org/largefiles/sire_releases/download.php?name=sire_2019_2_1_osx.run) : 2019.2.1 release compiled for OS X [534 MB]
+
+MD5Sum = cc397ce110a1c2de95e6103535c48a22
 
 ### Sire 2019.2.0
 


### PR DESCRIPTION
Feel free to ignore this if you think it's too technical, I just thought that it might be useful for some people. People might not also be familiar with ordering in dictionaries, since this wasn't true of the builtin Python dict before version 3.6 (I think).