### PR TITLE
Fix 2020.1.0 download links and update conda installation instructions

### DIFF
--- a/largefiles/sire_releases/redirect_sire_2020_1_0_linux.run
+++ b/largefiles/sire_releases/redirect_sire_2020_1_0_linux.run
@@ -1,1 +1,1 @@
-https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/KScT2vL4kbgp_vS-crr1b-Z_cteQMykfCWLLUap0Zbo/n/hugs/b/sire_releases/o/sire_2020_1_0_linux.run
+https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/mf0n0tMWa7gU0ps_U5impwagDies09TYuOHNOAPEc30vOvVhmzUeMSrhD1HuOeL6/n/hugs/b/sire_releases/o/sire_2020_1_0_linux.run

--- a/largefiles/sire_releases/redirect_sire_2020_1_0_osx.run
+++ b/largefiles/sire_releases/redirect_sire_2020_1_0_osx.run
@@ -1,1 +1,1 @@
-https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/DBhkHI2aqBCkGe_E8jhudDyEetLOkHNdW3lvyDe-2T8/n/hugs/b/sire_releases/o/sire_2020_1_0_osx.run
+https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/q4I6E8-1ejmxYMtPUr9-WXopRTvJdfdFKzoKWa-GGEVSyDVyQKTvmL6mjwV4JgAe/n/hugs/b/sire_releases/o/sire_2020_1_0_osx.run

--- a/pages/download.md
+++ b/pages/download.md
@@ -9,7 +9,14 @@ You have several choices for how you can download and get Sire working on your m
 
 Sire is available as a [Conda package](https://anaconda.org/michellab/sire).
 
-To install the latest release, run:
+We recommend installing Sire into a clean environment, e.g.:
+
+```
+conda create -n sire python=3.7
+conda activate sire
+```
+
+Then, to install the latest release, run:
 
 ```
 conda install -c conda-forge -c omnia -c michellab sire
@@ -21,12 +28,41 @@ To install the latest development version, run:
 conda install -c conda-forge -c omnia -c michellab/label/dev sire
 ```
 
+When following the commands above you might not always end up with the most
+recent version of Sire. This is because of the way that Conda scores different
+package versions in order to try to minimise the number of downloads and changes
+to the environment when performing an install or upgrade. To work around this,
+you can try one of the following:
+
+Use the `--all` flag to update all the installed packages within the environment:
+
+```
+conda install -c conda-forge -c omnia -c michellab sire --all
+```
+
+Try explicitly passing the version of Sire, e.g, for the 2020.1.0 release:
+
+```
+conda install -c conda-forge -c omnia -c michellab sire=2020.1.0
+```
+
 Unless you add the required channels to your Conda configuration, then you'll
 need to add them when updating, e.g., for the development package:
 
 ```
 conda update -c conda-forge -c omnia -c michellab/label/dev sire
 ```
+
+If you find that the Conda installation / upgrade is extremely slow, we recommend
+installing the [mamba](https://github.com/mamba-org/mamba) package and replacing
+all instances of `conda` in the commands above with `mamba`, e.g.:
+
+```
+mamba install -c conda-forge -c omnia -c michellab sire
+```
+
+Note that `mamba` uses different options and scoring metrics to `conda`, so
+the package resolution may be different for the the same command.
 
 ## [Download a Sire binary](binaries.md)
 

--- a/pages/source.md
+++ b/pages/source.md
@@ -2,19 +2,24 @@
 
 ## Latest Release
 
-Sire undergoes continual development, with releases made periodically 
-throughout the year representing the latest stable version. Here 
+Sire undergoes continual development, with releases made periodically
+throughout the year representing the latest stable version. Here
 is the latest source release, with older releases linked below.
 
-* [Sire_2018.2.0.tar.gz](https://github.com/michellab/Sire/archive/2018.2.0.tar.gz) : 2018.2.0 source code release
+* [Sire_2020.1.0.tar.gz](https://github.com/michellab/Sire/archive/2020.1.0.tar.gz) : 2020.1.0 source code release
 
 ## Older Releases
 
-We always recommend that you use the latest version of Sire, as 
-the volunteer nature of Sire means that it is unlikely that 
-bugfixes for new releases will be backported to older versions. 
+We always recommend that you use the latest version of Sire, as
+the volunteer nature of Sire means that it is unlikely that
+bugfixes for new releases will be backported to older versions.
 Here is the list of prior releases.
 
+* [Sire_2019.3.0.tar.gz](https://github.com/michellab/Sire/archive/2019.3.0.tar.gz) : 2019.3.0 source code release
+* [Sire_2019.2.1.tar.gz](https://github.com/michellab/Sire/archive/2019.2.1.tar.gz) : 2019.2.1 source code release
+* [Sire_2019.2.0.tar.gz](https://github.com/michellab/Sire/archive/2019.2.0.tar.gz) : 2019.2.0 source code release
+* [Sire_2019.1.0.tar.gz](https://github.com/michellab/Sire/archive/2019.1.0.tar.gz) : 2019.1.0 source code release
+* [Sire_2018.2.0.tar.gz](https://github.com/michellab/Sire/archive/2018.2.0.tar.gz) : 2018.2.0 source code release
 * [Sire_2018.1.1.tar.gz](https://github.com/michellab/Sire/archive/2018.1.1.tar.gz) : 2018.1.1 source code release
 * [Sire_2018.1.0.tar.gz](https://github.com/michellab/Sire/archive/2018.1.0.tar.gz) : 2018.1.0 source code release
 * [Sire_2017.3.0.tar.gz](https://github.com/michellab/Sire/archive/2017.3.0.tar.gz) : 2017.3.0 source code release
@@ -32,19 +37,19 @@ Here is the list of prior releases.
 
 ## Installation (Linux and Mac, Modern Versions)
 
-Sire can be compiled and installed on most Unix platforms. We have tested 
-it extensively on different flavours of Linux and Mac OS X. Sire is 
-entirely self-contained, depending only on a working (modern) C and C++ compiler, 
+Sire can be compiled and installed on most Unix platforms. We have tested
+it extensively on different flavours of Linux and Mac OS X. Sire is
+entirely self-contained, depending only on a working (modern) C and C++ compiler,
 and the build system cmake. You will need to use at least version 3.0 or above.
 
-Once you have a working C and C++ compiler, and a new enough version of 
+Once you have a working C and C++ compiler, and a new enough version of
 cmake, unpack the downloaded source file using
 
 ```
 tar -jxvf sire_XXX.tar.gz
 ```
 
-Change into the resulting directory. Inside, you should find a file called 
+Change into the resulting directory. Inside, you should find a file called
 `compile_sire.sh`. Run this file using;
 
 ```


### PR DESCRIPTION
I have fixed the download links for the 2020.1.0 release of Sire. (Not sure why they were broken, since I tested when I added them. Perhaps something to do with the Oracle downtime around Christmas?) I have also updated the list of source archives since I realised that hadn't updated the page for the last few releases. Finally, I've updated the conda installation instructions to include details on how to try to install the most recent version of Sire when conda fails to install it by default. For some reason this has become more of an issue since the 2020.1.0 release, where conda always seems to want to install 2019.3.0. (Presumably this is due to a change in the number of dependencies that we pull in, which is largely out of our control.) Note that these instructions will (hopefully) be updated once again following the 2021.1.0 release, when we should move entirely to the conda-forge ecosystem.