### PR TITLE
Use the C++11 random number generator facilities

### DIFF
--- a/chryswoods.com/beginning_openmp/critical.md
+++ b/chryswoods.com/beginning_openmp/critical.md
@@ -79,11 +79,11 @@ This algorithm to calculate pi is [described in more detail here](https://academ
 Note that you will need to use the following random number functions and square root functions;
 
 * C : `rand` and `sqrt`, contained in `math.h` and `stdlib.h`
-* C++ : `std::rand` and `std::sqrt`, contained in `cmath` and `cstdlib`
+* C++ : `std::sqrt`, contained in `cmath`
 * Fortran : `rand` and `sqrt`
 
 The Fortran `rand` function already generates a random number between 0 and 1. 
-To achieve this in C or C++ you need to write the following function;
+To achieve this in C you need to write the following function;
 
 ```c
 double rand_one()
@@ -95,6 +95,22 @@ double rand_one()
 To get a random number from -1 to 1 you need to use;
 
     (2 * rand()) - 1 or (2 * rand_one()) - 1
+
+In C++, you can use the standard library random number generators provied by the [`<random>` header](https://en.cppreference.com/w/cpp/header/random).
+This provides a `std::random_device` which is used to safely seed the random number generation, `std::default_random_engine` which is used to generate the random numbers, and `std::uniform_real_distribution` which provides those random numbers in a particular range. You can use it by putting, before the `#pragma omp parallel` part:
+
+```c++
+std::random_device rd;
+```
+
+then, inside the parallel section (so each thread gets their own):
+
+```c++
+std::default_random_engine generator(rd());
+std::uniform_real_distribution random(-1.0, 1.0);
+```
+
+and then extract random numbers using `random(generator)` which will be in the range -1.0 to 1.0.
 
 Here are the possible answers - take a look if you get stuck or you want to check your work;
 

--- a/chryswoods.com/beginning_openmp/critical_answer_cpp.md
+++ b/chryswoods.com/beginning_openmp/critical_answer_cpp.md
@@ -2,31 +2,31 @@
 
 ```c++
 #include <cmath>
-#include <cstdlib>
+#include <random>
 #include <iostream>
 
-double rand_one()
-{
-    return std::rand() / (RAND_MAX + 1.0);
-}
-
-int main(int argc, const char **argv)
+int main()
 {
     int n_inside = 0;
     int n_outside = 0;
-
+    
+    std::random_device rd;
+    
     #pragma omp parallel
     {
         int pvt_n_inside = 0;
         int pvt_n_outside = 0;
+        
+        std::minstd_rand generator(rd());
+        std::uniform_real_distribution random(-1.0, 1.0);
 
         #pragma omp for
         for (int i=0; i<1000000; ++i)
         {
-            double x = (2*rand_one()) - 1;
-            double y = (2*rand_one()) - 1;
+            double x = random(generator);
+            double y = random(generator);
 
-            double r = sqrt( x*x + y*y );
+            double r = std::sqrt( x*x + y*y );
 
             if (r < 1.0)
             {

--- a/chryswoods.com/beginning_openmp/reduction_answer_cpp.md
+++ b/chryswoods.com/beginning_openmp/reduction_answer_cpp.md
@@ -2,31 +2,31 @@
 
 ```c++
 #include <cmath>
-#include <cstdlib>
+#include <random>
 #include <iostream>
 
-double rand_one()
-{
-    return std::rand() / (RAND_MAX + 1.0);
-}
-
-int main(int argc, const char **argv)
+int main()
 {
     int n_inside = 0;
     int n_outside = 0;
-
+    
+    std::random_device rd;
+    
     #pragma omp parallel reduction(+ : n_inside, n_outside)
     {
         int pvt_n_inside = 0;
         int pvt_n_outside = 0;
+        
+        std::minstd_rand generator(rd());
+        std::uniform_real_distribution random(-1.0, 1.0);
 
         #pragma omp for
         for (int i=0; i<1000000; ++i)
         {
-            double x = (2*rand_one()) - 1;
-            double y = (2*rand_one()) - 1;
+            double x = random(generator);
+            double y = random(generator);
 
-            double r = sqrt( x*x + y*y );
+            double r = std::sqrt( x*x + y*y );
 
             if (r < 1.0)
             {


### PR DESCRIPTION
The C-style `rand()` function is not thread safe and seems to slow down the more threads you add. This switches to use the random number facilities in C++11 via the [`<random>` header](https://en.cppreference.com/w/cpp/header/random).

In my benchmarks it makes orders of magnitude improvements over using `rand()`. In fact `rand()` gets slower when you add threads.

|       | 1 thread | 2 threads | 3 threads | 4 threads |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| `rand()` | 35.3 ±   2.3 ms | 345.8 ±  75.8 ms | 131.4 ±  22.2 ms | 175.5 ±  12.9 ms |
| `<random>` | 27.0 ±   1.8 ms | 13.9 ±   1.1 ms | 9.6 ±   0.6 ms | 8.0 ±   1.7 ms |

Benchmark from:

```shell
$ g++ pi_old.cpp -O3 -o pi_old -fopenmp
$ g++ pi.cpp -O3 -o pi -fopenmp
$ hyperfine --parameter-scan num_threads 1 4 \
> 'env OMP_NUM_THREADS={num_threads} ./pi_old' \
> 'env OMP_NUM_THREADS={num_threads} ./pi'
```