### PR TITLE
Fixes to Parallel C++ notes

### DIFF
--- a/chryswoods.com/parallel_c++/README.md
+++ b/chryswoods.com/parallel_c++/README.md
@@ -32,7 +32,7 @@ which are open source and available for Windows, Linux or OS X.
 ***
 
 To start, you will need to download all of the course material. This
-is available by [clicking here](https://github.com/chryswoods/siremol.org/raw/master/chryswoods.com/parallel_c%2B%2B/workshop.tgz). This will download a file called
+is available by [clicking here](https://github.com/chryswoods/siremol.org/raw/main/chryswoods.com/parallel_c%2B%2B/workshop.tgz). This will download a file called
 `workshop.tgz`. Unpack this file using the command
 
 ```

--- a/chryswoods.com/parallel_c++/reduce.md
+++ b/chryswoods.com/parallel_c++/reduce.md
@@ -9,6 +9,8 @@ you summed together two lists of numbers using `map` using code such as this.
 ```c++
 #include "part1.h"
 
+using namespace part1;
+
 int sum(int x, int y)
 {
     return x + y;


### PR DESCRIPTION
Two small fixes to the Parallel C++ notes. Firstly the branch name has been changed, and secondly there was a missing `using namespace` statement.